### PR TITLE
classbench-tools: Fix nftables catch-all rule generation

### DIFF
--- a/classbench-tools/classbench-to-nftables.py
+++ b/classbench-tools/classbench-to-nftables.py
@@ -167,6 +167,8 @@ def parse_and_write_file(input_file, output_file):
                 if proto_str != "":
                     string_list += fr" ip protocol{proto_str} "
 
+            if not string_list.endswith(" "):
+                string_list += " "
             string_list += fr"counter {defaultAction}"
 
             output_file.write(string_list+"\n")


### PR DESCRIPTION
This PR fixes a missing whitespace in the generated nftables catch-all rules.
cc @jkoeppeler

**Steps to reproduce**

1. take the following test input:
```
@113.60.126.0/23        128.0.0.0/1     0 : 65535       0 : 65535       0x00/0x00       0x0000/0x0000
@113.0.0.0/8    0.0.0.0/0       0 : 65535       0 : 65535       0x01/0xFF       0x0000/0x0000
@0.0.0.0/0      139.0.0.0/8     0 : 65535       0 : 65535       0x06/0xFF       0x0000/0x0000
@0.0.0.0/0      0.0.0.0/0       0 : 65535       0 : 65535       0x06/0xFF       0x0000/0x0000
@0.0.0.0/0      0.0.0.0/0       0 : 65535       0 : 65535       0x00/0x00       0x0000/0x0000
```

2. generate nftables rules:
``` shell
python3 classbench-to-nftables.py -t test -c testchain -p forward -j accept -i /tmp/test.txt -o /tmp/test.nft
```

3. try to apply the generated ruleset:
```
nft -f test.nft
test.nft:7:18-33: Error: Could not process rule: No such file or directory
add rule ip test testchaincounter accept
                 ^^^^^^^^^^^^^^^^
```